### PR TITLE
Fix the last argument not to be discarded in dry run mode

### DIFF
--- a/lib/frontkick/command.rb
+++ b/lib/frontkick/command.rb
@@ -11,7 +11,7 @@ module Frontkick
       stdin, out, err, wait_thr, pid = nil
 
       cmd_array = cmd.kind_of?(Array) ? cmd : [cmd]
-      command = "#{cmd_array.first} #{Shellwords.shelljoin(cmd_array[1..-2])}"
+      command = "#{cmd_array.first} #{Shellwords.shelljoin(cmd_array[1..-1])}"
 
       if opts[:dry_run]
         return Result.new(:stdout => command, :stderr => '', :exit_code => 0, :duration => 0)


### PR DESCRIPTION
In the example below, the last `3` should be included, but not.
 
```
irb(main):006:0> Frontkick::Command.exec(['echo', '1', '2', '3'], :dry_run => 1).stdout
=> "echo 1 2"
```