### PR TITLE
Do not set result exitcode default to be 0

### DIFF
--- a/example/run.rb
+++ b/example/run.rb
@@ -1,4 +1,5 @@
 require 'frontkick'
 
 result = Frontkick.exec(["#{__dir__}/../experiment/cat_64k.rb"])
-puts result.stdout
+puts "exitstatus: #{result.exitstatus}"
+puts "stdout: #{result.stdout}"

--- a/lib/frontkick/result.rb
+++ b/lib/frontkick/result.rb
@@ -9,7 +9,7 @@ module Frontkick
     def initialize(params = {})
       @stdout = params[:stdout] || ""
       @stderr = params[:stderr] || ""
-      @exit_code = params[:exit_code] || 0
+      @exit_code = params[:exit_code] # exit_code would be nil if child process is killed -9
       @duration = params[:duration] || 0
     end
 


### PR DESCRIPTION
because Open3.popen3 would return nil if child process is killed by -9