### PR TITLE
Fix stringio error and deprecation warnings that occur when using Ruby 2.7.x

### DIFF
--- a/lib/frontkick.rb
+++ b/lib/frontkick.rb
@@ -6,7 +6,7 @@ require 'frontkick/result'
 
 module Frontkick
   def self.exec(*env_cmd, **opts, &block)
-    ::Frontkick::Command.exec(*env_cmd, opts, &block)
+    ::Frontkick::Command.exec(*env_cmd, **opts, &block)
   end
 
   def self.process_wait(pid)

--- a/lib/frontkick/command.rb
+++ b/lib/frontkick/command.rb
@@ -1,6 +1,7 @@
 require 'benchmark'
 require 'open3'
 require 'shellwords'
+require 'stringio'
 
 module Frontkick
   class Command


### PR DESCRIPTION
I use frontkick fairly extensively for scripting and whenever I tried using it in projects that were using ruby 2.7.x I noticed scripts that used to work would all of a sudden fail. Thankfully, this issue can be illustrated with one of the example scripts right here in this repo:

```bash
gem install frontkick --no-document
ruby example/env.rb
```

Yields the following warning and error:

```
/Users/[REDACTED]/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/frontkick-0.5.7/lib/frontkick.rb:9: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/[REDACTED]/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/frontkick-0.5.7/lib/frontkick/command.rb:7: warning: The called method `exec' is defined here
Traceback (most recent call last):
        2: from example/env.rb:3:in `<main>'
        1: from /Users/[REDACTED]/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/frontkick-0.5.7/lib/frontkick.rb:9:in `exec'
/Users/[REDACTED]/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/frontkick-0.5.7/lib/frontkick/command.rb:33:in `exec': uninitialized constant Frontkick::Command::StringIO (NameError)
```

Thankfully, both issues are relatively easy to fix. This PR adds a `require 'stringio'` to `lib/frontkick/command.rb` to clear the error, and adds a `**` to the `opts` arg passed to `Frontkick::Command.exec` to clear the warning.